### PR TITLE
Speed up log line parsing

### DIFF
--- a/src/custom/app.rs
+++ b/src/custom/app.rs
@@ -779,7 +779,7 @@ impl LogMonitor {
 use regex::Regex;
 lazy_static::lazy_static! {
 	static ref LOG_LINE_PATTERN: Regex =
-		Regex::new(r"\[(?P<time_string>[^ ]{27}) (?P<category>[A-Z]{4,6}) (?P<source>.*)\](?P<message>.*)").expect("The regex failed to compile. This is a bug.");
+		Regex::new(r"\[(?P<time_string>[^ ]{27}) (?P<category>[A-Z]{4,6}) (?P<source>[^\]]*)\] (?P<message>.*)").expect("The regex failed to compile. This is a bug.");
 }
 
 #[derive(PartialEq)]
@@ -1598,6 +1598,34 @@ pub fn restore_focus(app: &mut App) {
 			if let Some(debug_logfile) = app.get_debug_dashboard_logfile() {
 				app.set_logfile_with_focus(debug_logfile);
 			}
+		}
+	}
+}
+#[cfg(test)]
+mod tests {
+
+	mod log_parsing {
+		use std::str::FromStr;
+
+		use chrono::{DateTime, Utc};
+
+		use crate::custom::app::LogEntry;
+
+		#[test]
+		fn it_parses() {
+			let message_time = "2024-03-23T19:38:32.350118Z";
+			let source = "sn_networking::event";
+			let category = "WARN";
+			let message = "MsgReceivedError: InternalMsgChannelDropped";
+			let line = format!("[{} {} {}] {}", message_time, category, source, message);
+			let metadata = LogEntry::decode_metadata(&line).unwrap();
+
+			let message_time: DateTime<Utc> = DateTime::from_str(message_time).unwrap();
+
+			assert_eq!(metadata.category, category);
+			assert_eq!(metadata.message_time, message_time);
+			assert_eq!(metadata.source, source);
+			assert_eq!(metadata.message, message);
 		}
 	}
 }


### PR DESCRIPTION
The source capture group was trying to match beyond the closing square bracket `]`. Limiting the search to the first square bracket saves a fair bit of work


The flamegraphs aren't rendering ideally on Github, but very rough numbers from a test against a single 300MB log file on an M1 Mac Pro:
Around 64% of samples were taken in the `decode_metadata` function before the change.
Around 45% of samples were taken in the `decode_metadata` function after the change.


Pre change flamegraph:
![pre-change 300MB logfile](https://github.com/happybeing/vdash/assets/18317099/5919e700-8c85-4dcb-9135-6acef5e06ab3)


Post change flamegraph:

![post-change 300MB logfile](https://github.com/happybeing/vdash/assets/18317099/7e15a222-c298-4f37-b12b-fb423e5d7689)
